### PR TITLE
Fix/use tarball url from package config

### DIFF
--- a/modules/utils/npm.js
+++ b/modules/utils/npm.js
@@ -167,10 +167,11 @@ export async function getPackageConfig(packageName, version, log) {
  * Returns a stream of the tarball'd contents of the given package.
  */
 export async function getPackage(packageName, version, log) {
-  const tarballName = isScopedPackageName(packageName)
-    ? packageName.split('/')[1]
-    : packageName;
-  const tarballURL = `${npmRegistryURL}/${packageName}/-/${tarballName}-${version}.tgz`;
+  const packageConfig = getPackageConfig(packageName, version, log);
+  if (!packageConfig && !packageConfig.dist && !packageConfig.dist.tarball) {
+    return null;
+  }
+  const tarballURL = packageConfig.dist.tarball;
 
   log.debug('Fetching package for %s from %s', packageName, tarballURL);
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "supertest": "^3.0.0"
   },
   "engines": {
-    "node": "10.x.x"
+    "node": "12.x.x"
   }
 }


### PR DESCRIPTION
To prevent problems with scoped packages in registries like artifactory it would be better to use the tarball url from the package config instead of a template string.