### PR TITLE
Enable work with scoped names of GitLab npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ node node_modules/unpkg-server/server.js \
 
 These values can be set on the system environment when starting the unpkg `server.js`.
 
-| Flag                   | Options / Description                            | Default value                |
-| ---------------------- | ------------------------------------------------ | ---------------------------- |
-| `NPM_REGISTRY_URL`     | optional - private registry url                  | `https://registry.npmjs.org` |
-| `PORT`                 | optional - port to listen on                     | `8080`                       |
-| `GOOGLE_CLOUD_PROJECT` | The GCP project ID.                              | `null`                       |
-| `GAE_ENV`              | `standard` to enable `@google-cloud/trace-agent` | `null`                       |
-| `DEBUG`                | enableDebugging                                  | `false`                      |
-| `ENABLE_CLOUDFLARE`    | optional `true` or `false`                       | `false`                      |
-| `ORIGIN`               | optional                                         | `https://unpkg.com`          |
-| `CLOUDFLARE_EMAIL`     | optional                                         | `null`                       |
-| `CLOUDFLARE_KEY`       | optional                                         | `null`                       |
-| `GITLAB_REGISTRY`      | optional - enable work with GitLab npm registry  | `null`                       |
+| Flag                   | Options / Description                                  | Default value                |
+| ---------------------- | ------------------------------------------------------ | ---------------------------- |
+| `NPM_REGISTRY_URL`     | optional - private registry url                        | `https://registry.npmjs.org` |
+| `PORT`                 | optional - port to listen on                           | `8080`                       |
+| `GOOGLE_CLOUD_PROJECT` | The GCP project ID.                                    | `null`                       |
+| `GAE_ENV`              | `standard` to enable `@google-cloud/trace-agent`       | `null`                       |
+| `DEBUG`                | enableDebugging                                        | `false`                      |
+| `ENABLE_CLOUDFLARE`    | optional `true` or `false`                             | `false`                      |
+| `ORIGIN`               | optional                                               | `https://unpkg.com`          |
+| `CLOUDFLARE_EMAIL`     | optional                                               | `null`                       |
+| `CLOUDFLARE_KEY`       | optional                                               | `null`                       |
+| `GITLAB_REGISTRY`      | optional - enable work with GitLab npm scoped packages | `null`                       |
 
 ## Build Options
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These values can be set on the system environment when starting the unpkg `serve
 | `CLOUDFLARE_EMAIL`     | optional                                               | `null`                       |
 | `CLOUDFLARE_KEY`       | optional                                               | `null`                       |
 | `GITLAB_REGISTRY`      | optional - enable work with GitLab npm scoped packages | `null`                       |
+| `CACHE_CONTROL`        | optional - overrides response header                   | `public,max-age=31536000`    |
 
 ## Build Options
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ These values can be set on the system environment when starting the unpkg `serve
 | `ORIGIN`               | optional                                         | `https://unpkg.com`          |
 | `CLOUDFLARE_EMAIL`     | optional                                         | `null`                       |
 | `CLOUDFLARE_KEY`       | optional                                         | `null`                       |
+| `GITLAB_REGISTRY`      | optional - enable work with GitLab npm registry  | `null`                       |
 
 ## Build Options
 
@@ -61,6 +62,7 @@ Use a `.env` file to set the following options when building the app with `npm r
 ## Documentation
 
 Please visit [the UNPKG website](https://unpkg.com) to learn more about how to use it.
+Visit [GitLab docs](https://docs.gitlab.com/ee/api/packages/npm.html) to learn more about npm rigestry in GitLab.
 
 ## Sponsors
 

--- a/modules/actions/serveFile.js
+++ b/modules/actions/serveFile.js
@@ -10,12 +10,15 @@ export default function serveFile(req, res) {
   if (ext) {
     tags.push(`${ext}-file`);
   }
-
+  const cacheControl =
+   process.env.CACHE_CONTROL;
   res
     .set({
       'Content-Type': getContentTypeHeader(req.entry.contentType),
       'Content-Length': req.entry.size,
-      'Cache-Control': 'public, max-age=31536000', // 1 year
+      'Cache-Control': cacheControl 
+                     ? cacheControl 
+                     : 'public, max-age=31536000', // 1 year
       'Last-Modified': req.entry.lastModified,
       ETag: etag(req.entry.content),
       'Cache-Tag': tags.join(', ')

--- a/modules/utils/npm.js
+++ b/modules/utils/npm.js
@@ -8,6 +8,9 @@ import bufferStream from './bufferStream.js';
 const npmRegistryURL =
   process.env.NPM_REGISTRY_URL || 'https://registry.npmjs.org';
 
+const gitlabRegistry =
+   process.env.GITLAB_REGISTRY;
+
 const agent = new https.Agent({
   keepAlive: true
 });
@@ -167,7 +170,7 @@ export async function getPackageConfig(packageName, version, log) {
  * Returns a stream of the tarball'd contents of the given package.
  */
 export async function getPackage(packageName, version, log) {
-  const tarballName = isScopedPackageName(packageName)
+  const tarballName = isScopedPackageName(packageName) && !gitlabRegistry
     ? packageName.split('/')[1]
     : packageName;
   const tarballURL = `${npmRegistryURL}/${packageName}/-/${tarballName}-${version}.tgz`;


### PR DESCRIPTION
GitLab uses scoped name convention. We can see it in docs and in tarball links. 
Example:
`
curl --header "Authorization: Bearer <personal_access_token>" "https://gitlab.example.com/api/v4/projects/1/packages/npm/@myscope/my-pkg/-/@my-scope/my-pkg-0.0.1.tgz"
`

Now by adding --GITLAB_REGISTRY we can turn off splitting tarballName in `async function getPackage(packageName, version, log)`.